### PR TITLE
fix SingleSelectWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.0.7] - 2026-07-16
+
+### Fixes
+
+- `SingleSelectWidget`: Reopening the dropdown while an item is selected now clears the search text (showing the selected value as a placeholder) and resets the search query, so the popup shows the full list instead of the stale filtered result.
+
 ## [3.0.6] - 2026-04-14
 
 - `SingleSelectWidget` and `MultipleSelectWidget` add `resetSelectedIds` function.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.5"
+    version: "3.0.6"
   characters:
     dependency: transitive
     description:
@@ -134,10 +134,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -195,10 +195,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -216,5 +216,5 @@ packages:
     source: hosted
     version: "14.3.1"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/components/select/single_select_widget.dart
+++ b/lib/src/components/select/single_select_widget.dart
@@ -376,6 +376,22 @@ class _SingleSelectWidgetState extends State<SingleSelectWidget>
         _buttonKey.currentContext?.findRenderObject() as RenderBox?;
     if (renderBox == null) return;
 
+    /// 已选中数据的情况下，如果输入框当前展示的还是失焦时自动回填的已选项名称
+    /// （即用户还没有输入新的检索内容），重新打开下拉时清空文本、重置检索词，
+    /// 已选项名称改为以 placeholder 形式展示，下拉框恢复展示全部数据
+    if (_multipleSelectWidgetController.selectedList.isNotEmpty) {
+      final selectedName =
+          _multipleSelectWidgetController.selectedList.first.name;
+      if (_textEditingController.text == selectedName) {
+        _isProgrammaticallyChangingText = true;
+        _textEditingController.clear();
+        _multipleSelectWidgetController.setSearchQuery('');
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _isProgrammaticallyChangingText = false;
+        });
+      }
+    }
+
     final position = renderBox.localToGlobal(
       Offset.zero,
       ancestor:
@@ -610,10 +626,11 @@ class _CustomInputDecorator extends StatelessWidget {
     return InputDecoration(
       isCollapsed: true,
       enabled: false,
-      hintText: multipleSelectWidgetController.selectedList.isEmpty &&
-              (textEditingController?.text ?? '').isEmpty
-          ? fieldDecoration.hintText
-          : '',
+      hintText: (textEditingController?.text ?? '').isNotEmpty
+          ? ''
+          : multipleSelectWidgetController.selectedList.isNotEmpty
+              ? multipleSelectWidgetController.selectedList.first.name
+              : fieldDecoration.hintText,
       hintStyle: fieldDecoration.hintStyle,
       filled: fieldDecoration.backgroundColor != null,
       fillColor: fieldDecoration.backgroundColor,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cascade_widget
 description: "A versatile Flutter cascade selection widget, offering multi-level cascading dropdowns with single and multiple selection options. Ideal for web and desktop applications."
-version: 3.0.6
+version: 3.0.7
 homepage: https://github.com/superSong-hello/cascade_widget
 repository: https://github.com/superSong-hello/cascade_widget
 


### PR DESCRIPTION
## [3.0.7] - 2026-07-16

### Fixes

- `SingleSelectWidget`: Reopening the dropdown while an item is selected now clears the search text (showing the selected value as a placeholder) and resets the search query, so the popup shows the full list instead of the stale filtered result.
