### PR TITLE
fix widget width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [3.0.8] - 2026-07-17
+
+### Features
+
+- **Customizable Popup Width**: Added `overlayWidth` to `PopupConfig` for `SingleSelectWidget` and `MultipleSelectWidget`. When unset, the popup still auto-matches the trigger control's width (previous default behavior); set it to override with a fixed width.
+
+### Fixes
+
+- **Popup Screen-Edge Overflow**: The popup for `SingleSelectWidget`, `MultipleSelectWidget`, `CascadeWidget`, and `SingleSelectCascadeWidget` is now shifted left when it would otherwise render past the right edge of the screen (e.g. a wide `overlayWidth`, or a cascade with several expanded levels).
+- **Cascade Tap-Outside Detection**: Corrected the outside-tap hit-test area in `CascadeWidget` and `SingleSelectCascadeWidget` to account for the popup's actual rendered width/height (including the screen-edge shift above), preventing taps inside the popup from being misread as taps outside it.
+
 ## [3.0.7] - 2026-07-16
 
 ### Fixes

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -459,6 +459,38 @@ class _MyHomePageState extends State<MyHomePage> {
                     ),
                   ),
                 ),
+                const _Title(
+                    'Pure Single Select Widget (custom popup width)'),
+                SizedBox(
+                  width: 150,
+                  child: _Card(
+                    child: SingleSelectWidget(
+                      list: pureSingleList,
+                      selectedCallBack: (selectedList) {
+                        debugPrint('Pure single select callback:');
+                        for (final e in selectedList) {
+                          debugPrint('name:${e.name}, id:${e.id}');
+                        }
+                      },
+                      fieldDecoration: FieldDecoration(
+                        backgroundColor: Colors.white,
+                        hintText: 'Please select',
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(4),
+                          borderSide: const BorderSide(color: Colors.grey),
+                        ),
+                        showClearIcon: false,
+                      ),
+                      // The field above is only 150 wide, but overlayWidth
+                      // forces the popup to render at a fixed 320 wide
+                      // instead of auto-matching the field's width.
+                      popupConfig: const PopupConfig(
+                        isShowSearchInput: true,
+                        overlayWidth: 320,
+                      ),
+                    ),
+                  ),
+                ),
               ],
             ),
           ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.7"
+    version: "3.0.8"
   characters:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.6"
+    version: "3.0.7"
   characters:
     dependency: transitive
     description:

--- a/lib/src/components/cascade/cascade_widget.dart
+++ b/lib/src/components/cascade/cascade_widget.dart
@@ -498,8 +498,13 @@ class _CustomInputDecorator extends StatelessWidget {
                     (globalPosition?.dy ?? 0) +
                         (tapedRenderBox?.size.height ?? 0),
                     contentWidth,
+                    // +16 matches the popup content's own outer padding
+                    // (see _PopupListContentWidget/_PopupTreeContentWidget's
+                    // `listViewHeight + 16`), so this rect matches its actual
+                    // rendered height.
                     (tapedRenderBox?.size.height ?? 0) +
-                        popupConfig.popupHeight,
+                        popupConfig.popupHeight +
+                        16,
                   );
                   Rect extraRenderBoxFrame = renderBoxFrame.inflate(5);
                   if (extraRenderBoxFrame.contains(event.position) &&

--- a/lib/src/components/cascade/cascade_widget.dart
+++ b/lib/src/components/cascade/cascade_widget.dart
@@ -261,6 +261,18 @@ class _CascadeWidgetState extends State<CascadeWidget>
             double screenHeight = MediaQuery.of(context).size.height;
             final Color maskColor = widget.popupConfig.overlayColor;
 
+            // The tree view's actual width grows with the number of expanded
+            // levels (popupWidth * columns + 24); clamp the left offset so a
+            // wide popup doesn't overflow past the right edge of the screen.
+            final finalWidth = _textEditingController.text.isNotEmpty
+                ? width.toDouble()
+                : widget.popupConfig.popupWidth *
+                        _cascadeController.uiList.length +
+                    24;
+            final leftPosition = (position.dx + finalWidth > screenWidth)
+                ? (screenWidth - finalWidth).clamp(0.0, position.dx)
+                : position.dx;
+
             return Stack(
               children: [
                 if (widget.popupConfig.isShowOverlay) ...[
@@ -314,7 +326,7 @@ class _CascadeWidgetState extends State<CascadeWidget>
                   )
                 ],
                 Positioned(
-                  left: position.dx + 0,
+                  left: leftPosition,
                   top: position.dy + height,
                   child: Material(
                     color: Colors.transparent,
@@ -471,9 +483,18 @@ class _CustomInputDecorator extends StatelessWidget {
                   final contentWidth = cascadeController.isShopSearchView
                       ? (tapedRenderBox?.size.width ?? 0)
                       : (popupConfig.popupWidth *
-                          cascadeController.uiList.length);
+                              cascadeController.uiList.length +
+                          24);
+                  final screenWidth = MediaQuery.of(context).size.width;
+                  final fieldLeft = globalPosition?.dx ?? 0;
+                  // Mirror the same left-offset clamp used to position the
+                  // popup itself, so this hit-test rect stays in sync with
+                  // where the popup actually renders when it's clamped.
+                  final contentLeft = (fieldLeft + contentWidth > screenWidth)
+                      ? (screenWidth - contentWidth).clamp(0.0, fieldLeft)
+                      : fieldLeft;
                   Rect renderBoxFrame = Rect.fromLTWH(
-                    globalPosition?.dx ?? 0,
+                    contentLeft,
                     (globalPosition?.dy ?? 0) +
                         (tapedRenderBox?.size.height ?? 0),
                     contentWidth,

--- a/lib/src/components/cascade/singel_select_cascade_widget.dart
+++ b/lib/src/components/cascade/singel_select_cascade_widget.dart
@@ -502,8 +502,13 @@ class _CustomInputDecorator extends StatelessWidget {
                     (globalPosition?.dy ?? 0) +
                         (tapedRenderBox?.size.height ?? 0),
                     contentWidth,
+                    // +16 matches the popup content's own outer padding
+                    // (see _PopupListContentWidget/_PopupTreeContentWidget's
+                    // `listViewHeight + 16`), so this rect matches its actual
+                    // rendered height.
                     (tapedRenderBox?.size.height ?? 0) +
-                        popupConfig.popupHeight,
+                        popupConfig.popupHeight +
+                        16,
                   );
                   Rect extraRenderBoxFrame = renderBoxFrame.inflate(5);
                   if (extraRenderBoxFrame.contains(event.position) &&

--- a/lib/src/components/cascade/singel_select_cascade_widget.dart
+++ b/lib/src/components/cascade/singel_select_cascade_widget.dart
@@ -263,6 +263,18 @@ class _SingleSelectCascadeWidgetState extends State<SingleSelectCascadeWidget>
             double screenHeight = MediaQuery.of(context).size.height;
             final Color maskColor = widget.popupConfig.overlayColor;
 
+            // The tree view's actual width grows with the number of expanded
+            // levels (popupWidth * columns + 24); clamp the left offset so a
+            // wide popup doesn't overflow past the right edge of the screen.
+            final finalWidth = _textEditingController.text.isNotEmpty
+                ? width.toDouble()
+                : widget.popupConfig.popupWidth *
+                        _cascadeController.uiList.length +
+                    24;
+            final leftPosition = (position.dx + finalWidth > screenWidth)
+                ? (screenWidth - finalWidth).clamp(0.0, position.dx)
+                : position.dx;
+
             return Stack(
               children: [
                 if (widget.popupConfig.isShowOverlay) ...[
@@ -316,7 +328,7 @@ class _SingleSelectCascadeWidgetState extends State<SingleSelectCascadeWidget>
                   )
                 ],
                 Positioned(
-                  left: position.dx + 0,
+                  left: leftPosition,
                   top: position.dy + height,
                   child: Material(
                     color: Colors.transparent,
@@ -475,9 +487,18 @@ class _CustomInputDecorator extends StatelessWidget {
                   final contentWidth = cascadeController.isShopSearchView
                       ? (tapedRenderBox?.size.width ?? 0)
                       : (popupConfig.popupWidth *
-                          cascadeController.uiList.length);
+                              cascadeController.uiList.length +
+                          24);
+                  final screenWidth = MediaQuery.of(context).size.width;
+                  final fieldLeft = globalPosition?.dx ?? 0;
+                  // Mirror the same left-offset clamp used to position the
+                  // popup itself, so this hit-test rect stays in sync with
+                  // where the popup actually renders when it's clamped.
+                  final contentLeft = (fieldLeft + contentWidth > screenWidth)
+                      ? (screenWidth - contentWidth).clamp(0.0, fieldLeft)
+                      : fieldLeft;
                   Rect renderBoxFrame = Rect.fromLTWH(
-                    globalPosition?.dx ?? 0,
+                    contentLeft,
                     (globalPosition?.dy ?? 0) +
                         (tapedRenderBox?.size.height ?? 0),
                     contentWidth,

--- a/lib/src/components/select/multiple_select_widget.dart
+++ b/lib/src/components/select/multiple_select_widget.dart
@@ -246,6 +246,15 @@ class _MultipleSelectWidgetState extends State<MultipleSelectWidget>
         double screenHeight = MediaQuery.of(context).size.height;
         final Color maskColor = widget.popupConfig.overlayColor;
 
+        // When a custom overlayWidth is wider than the available space to the
+        // right of the field, clamp the popup's left offset so it stays on
+        // screen instead of overflowing past the screen edge.
+        final finalWidth = widget.popupConfig.overlayWidth ?? width.toDouble();
+        final leftPosition =
+            (position.dx + finalWidth > screenWidth)
+                ? (screenWidth - finalWidth).clamp(0.0, position.dx)
+                : position.dx;
+
         return Stack(
           children: [
             if (widget.popupConfig.isShowOverlay) ...[
@@ -303,7 +312,7 @@ class _MultipleSelectWidgetState extends State<MultipleSelectWidget>
               )
             ],
             Positioned(
-              left: position.dx + 0,
+              left: leftPosition,
               top: topPosition,
               child: Material(
                 color: Colors.transparent,
@@ -329,7 +338,7 @@ class _MultipleSelectWidgetState extends State<MultipleSelectWidget>
                                 multipleSelectWidgetController:
                                     _multipleSelectWidgetController,
                                 listViewHeight: finalHeight,
-                                listViewWidth: width.toDouble(),
+                                listViewWidth: finalWidth,
                                 popupDecoration: widget.popupConfig,
                                 hideOverlay: hideOverlay,
                                 isSingleChoice: widget.isSingleChoice,

--- a/lib/src/components/select/single_select_widget.dart
+++ b/lib/src/components/select/single_select_widget.dart
@@ -263,6 +263,15 @@ class _SingleSelectWidgetState extends State<SingleSelectWidget>
         double screenHeight = MediaQuery.of(context).size.height;
         final Color maskColor = widget.popupConfig.overlayColor;
 
+        // When a custom overlayWidth is wider than the available space to the
+        // right of the field, clamp the popup's left offset so it stays on
+        // screen instead of overflowing past the screen edge.
+        final finalWidth = widget.popupConfig.overlayWidth ?? width.toDouble();
+        final leftPosition =
+            (position.dx + finalWidth > screenWidth)
+                ? (screenWidth - finalWidth).clamp(0.0, position.dx)
+                : position.dx;
+
         return Stack(
           children: [
             if (widget.popupConfig.isShowOverlay) ...[
@@ -320,7 +329,7 @@ class _SingleSelectWidgetState extends State<SingleSelectWidget>
               )
             ],
             Positioned(
-              left: position.dx + 0,
+              left: leftPosition,
               top: topPosition,
               child: Material(
                 color: Colors.transparent,
@@ -346,7 +355,7 @@ class _SingleSelectWidgetState extends State<SingleSelectWidget>
                                 multipleSelectWidgetController:
                                     _multipleSelectWidgetController,
                                 listViewHeight: finalHeight,
-                                listViewWidth: width.toDouble(),
+                                listViewWidth: finalWidth,
                                 popupDecoration: widget.popupConfig,
                                 hideOverlay: hideOverlay,
                                 isPopupAbove: _isPopupAbove,

--- a/lib/src/config/popup_config.dart
+++ b/lib/src/config/popup_config.dart
@@ -23,11 +23,25 @@ class PopupConfig {
   });
 
   /// The width of each list view within the popup.
+  ///
+  /// For cascade widgets (e.g. [CascadeWidget], [SingleSelectCascadeWidget])
+  /// the popup's total width grows with the number of expanded levels
+  /// (`popupWidth * levels`), so it can exceed the screen width faster than
+  /// this value alone suggests. As with [overlayWidth], the popup is shifted
+  /// left to stay on screen but that shift is capped at the trigger
+  /// control's own left edge — a large [popupWidth] combined with many
+  /// levels can still overflow on the right.
   final double popupWidth;
 
   /// The width of the popup overlay for select widgets (e.g. [SingleSelectWidget],
   /// [MultipleSelectWidget]). When null, the overlay automatically matches the
   /// width of the trigger control.
+  ///
+  /// If the overlay would extend past the right edge of the screen, it is
+  /// shifted left just enough to stay fully on screen. That shift is capped
+  /// at the trigger control's own left edge, so a value wider than the
+  /// available screen width will still overflow on the right — keep
+  /// [overlayWidth] within the width of the screens you support.
   final double? overlayWidth;
 
   /// The height of the popup menu.

--- a/lib/src/config/popup_config.dart
+++ b/lib/src/config/popup_config.dart
@@ -7,6 +7,7 @@ class PopupConfig {
   /// Creates a configuration for the popup menu.
   const PopupConfig({
     this.popupWidth = 180,
+    this.overlayWidth,
     this.popupHeight = 350,
     this.checkBoxActiveColor,
     this.textStyle,
@@ -23,6 +24,11 @@ class PopupConfig {
 
   /// The width of each list view within the popup.
   final double popupWidth;
+
+  /// The width of the popup overlay for select widgets (e.g. [SingleSelectWidget],
+  /// [MultipleSelectWidget]). When null, the overlay automatically matches the
+  /// width of the trigger control.
+  final double? overlayWidth;
 
   /// The height of the popup menu.
   final double popupHeight;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cascade_widget
 description: "A versatile Flutter cascade selection widget, offering multi-level cascading dropdowns with single and multiple selection options. Ideal for web and desktop applications."
-version: 3.0.7
+version: 3.0.8
 homepage: https://github.com/superSong-hello/cascade_widget
 repository: https://github.com/superSong-hello/cascade_widget
 


### PR DESCRIPTION
## [3.0.8] - 2026-07-17

### Features

- **Customizable Popup Width**: Added `overlayWidth` to `PopupConfig` for `SingleSelectWidget` and `MultipleSelectWidget`. When unset, the popup still auto-matches the trigger control's width (previous default behavior); set it to override with a fixed width.

### Fixes

- **Popup Screen-Edge Overflow**: The popup for `SingleSelectWidget`, `MultipleSelectWidget`, `CascadeWidget`, and `SingleSelectCascadeWidget` is now shifted left when it would otherwise render past the right edge of the screen (e.g. a wide `overlayWidth`, or a cascade with several expanded levels).
- **Cascade Tap-Outside Detection**: Corrected the outside-tap hit-test area in `CascadeWidget` and `SingleSelectCascadeWidget` to account for the popup's actual rendered width/height (including the screen-edge shift above), preventing taps inside the popup from being misread as taps outside it.
